### PR TITLE
Fixed runtime failures without a config file

### DIFF
--- a/src/lesshintMutationsProvider.ts
+++ b/src/lesshintMutationsProvider.ts
@@ -33,7 +33,6 @@ export class LesshintMutationsProvider implements IMutationsProvider {
     public constructor(settings: IMutationsProviderSettings) {
         this.settings = {
             reporter: settings.reporter,
-            suggestFixes: true,
             ...settings
         };
     }

--- a/src/lesshintWaveReporter.ts
+++ b/src/lesshintWaveReporter.ts
@@ -65,7 +65,7 @@ export class LesshintWaveReporter {
                     const linesRaw: string[] = fileContents.match(/[^\n]+(?:\r?\n|$)/g) as string[];
                     const suggestedFix = await this.rootSuggester.suggestMutation(
                         complaint,
-                        this.configs[complaint.linter],
+                        this.configs[complaint.linter] || {},
                         {
                             linesRaw,
                             text: fileContents


### PR DESCRIPTION
When running without a config file, it would fail to read the undefined path.
Fixes #62.